### PR TITLE
fix the composer require command

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Go to https://phprbac.net/ :) to have the representation of permissions and role
 
 just include the package with composer:
 
-<pre>composer require olivier127/phprbac-bundle</pre>
+<pre>composer require olivier127/rbac-bundle</pre>
 
 register the bundle inside config/bundles.php
 


### PR DESCRIPTION
you have wrong composer require command in the readme. no olivier127/phprbac-bundle exists on packagist, it's just olivier127/rbac-bundle like the name of the repo...