### PR TITLE
Refactor RoleRepository for compaitibility with Doctrine 3

### DIFF
--- a/src/Repository/RoleRepository.php
+++ b/src/Repository/RoleRepository.php
@@ -57,9 +57,9 @@ class RoleRepository extends ServiceEntityRepository implements NestedSetInterfa
      */
     public function add(Role $entity, bool $flush = true): void
     {
-        $this->_em->persist($entity);
+        $this->getEntityManager()->persist($entity);
         if ($flush) {
-            $this->_em->flush();
+            $this->getEntityManager()->flush();
         }
     }
 
@@ -69,9 +69,9 @@ class RoleRepository extends ServiceEntityRepository implements NestedSetInterfa
      */
     public function remove(Role $entity, bool $flush = true): void
     {
-        $this->_em->remove($entity);
+        $this->getEntityManager()->remove($entity);
         if ($flush) {
-            $this->_em->flush();
+            $this->getEntityManager()->flush();
         }
     }
 


### PR DESCRIPTION
`_em` was made private in Doctrine 3, and is no longer directly accessible. This should fix the issue of Roles not being added