### PR TITLE
Remove compiler pass deprecation message

### DIFF
--- a/src/DependencyInjection/Compiler/DoctrineResolveTargetEntityPass.php
+++ b/src/DependencyInjection/Compiler/DoctrineResolveTargetEntityPass.php
@@ -10,7 +10,7 @@ use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 
 class DoctrineResolveTargetEntityPass implements CompilerPassInterface
 {
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         $resolveTargetEntityListener = $container->findDefinition('doctrine.orm.listeners.resolve_target_entity');
 


### PR DESCRIPTION
This PR addresses the deprecation notice received when implementing Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface without a native return type declaration.

The specific warning is:

Method "Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface::process()" might add "void" as a native return type declaration in the future.

 have explicitly added the void return type declaration to the process() method in all affected classes that implement CompilerPassInterface.

This ensures forward compatibility with future versions of Symfony (specifically, Symfony 6.4 and later )
